### PR TITLE
[Fix] release asset upload url wasn't supposed to be in bash scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
           -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}"
           -H "Content-Type: application/octet-stream"
           --data-binary "@${artifact}"
-          "${{ steps.create_release.outputs.upload_url }}?name=${artifact}"
+          "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.create_release.outputs.id }}/assets?name=${artifact}&label=${artifact}"
 
           done < "${{ steps.list_artifacts.outputs.artifact_urls_file }}"
 


### PR DESCRIPTION
# Description

Nothing!


# Checklist

- [ ] Your code works
- [ ] The changes are cool
- [ ] The version is bumped
