### PR TITLE
[Change] Added manual workflow that tears down github runners. validate-version-action bumped to 1.2.0. Checking terraform show in the scheduled runs now.

### DIFF
--- a/.github/workflows/build_tdlib.yml
+++ b/.github/workflows/build_tdlib.yml
@@ -87,11 +87,11 @@ jobs:
         shell: bash
         run: >-
           if [[ -z "${{ steps.get_version_commit.outputs.version_commit }}" ]]; then
-            
+
             echo "Couldn't find commit
           for planned version '${{ steps.validate_new_version.outputs.planned_version }}':
           '${{ steps.get_version_commit.outputs.version_commit }}'"
-            
+
             exit 127
 
           fi
@@ -131,7 +131,7 @@ jobs:
           )
 
           TOKEN_FILENAME="${PWD}/.ghr_token"
-          
+
           echo "${TOKEN}" > "${TOKEN_FILENAME}"
 
           if [[ -z "${TOKEN}" ]]; then
@@ -143,9 +143,9 @@ jobs:
           else
 
             echo "Successfully obtained GitHub runner registration token."
-            
+
             echo "::set-output name=token::${TOKEN}"
-            
+
             echo "::set-output name=token_filename::${TOKEN_FILENAME}"
 
           fi
@@ -222,7 +222,7 @@ jobs:
           cat <<EOF > outputs.json
           ${{ steps.terraform_show.outputs.stdout }}
           EOF
-          
+
           cat <<EOF >> "${GITHUB_OUTPUT}"
           instances<<EOF2
           $( cat outputs.json | jq -r '.values.outputs."instance-details".value[][] | .name + "\n" + .ipv4 + "\n" + .ipv6 + "\n"' )
@@ -242,7 +242,7 @@ jobs:
             <b>Instances:</b>
             ${{ steps.parse_terraform_show.outputs.instances }}
 
-            <b>Outcome:</b> 
+            <b>Outcome:</b>
             terraform init: ${{ steps.terraform_init.outcome }}
             terraform plan: ${{ steps.terraform_plan.outcome }}
             terraform apply: ${{ steps.terraform_apply.outcome }}
@@ -283,7 +283,7 @@ jobs:
 
     strategy:
       matrix:
-        version: 
+        version:
           - ${{ needs.validate_new_version.outputs.planned_version }}
         runs-on:
 
@@ -420,7 +420,7 @@ jobs:
             Label: ${{ matrix.runs-on.label }}
             Arch: ${{ matrix.runs-on.arch }}
 
-            <b>Outcome:</b> 
+            <b>Outcome:</b>
             install_dependencies: ${{ steps.install_dependencies.outcome }}
             checkout_tdlib_repo: ${{ steps.checkout_tdlib_repo.outcome }}
             print_directory_contents: ${{ steps.print_directory_contents.outcome }}

--- a/.github/workflows/build_tdlib.yml
+++ b/.github/workflows/build_tdlib.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Use latest released action
         id: validate_new_version
-        uses: reinvented-stuff/validate-version-action@master
+        uses: reinvented-stuff/validate-version-action@1.2.0
         with:
           version_filename: ".version"
           github_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Use latest released action
         id: validate_new_version
-        uses: reinvented-stuff/validate-version-action@master
+        uses: reinvented-stuff/validate-version-action@1.2.0
         with:
           version_filename: ".version"
           github_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,8 @@ jobs:
       - validate_new_version
 
     if: >
-      github.event_name == 'push'
+      github.event_name == 'push' &&
+      needs.validate_new_version.outputs.can_create == 'true'
 
     steps:
 

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -99,7 +99,7 @@ jobs:
           terraform show -json |
           jq -r '.values.outputs."instance-details".value[][] | .name + "\n" + .ipv4 + "\n" + .ipv6 + "\n"' >
           "outputs.json"
-          
+
           cat <<EOF >> "${GITHUB_OUTPUT}"
           instances<<EOF2
           $( cat outputs.json  )
@@ -119,7 +119,7 @@ jobs:
             <b>Instances:</b>
             ${{ steps.terraform_show.outputs.instances }}
 
-            <b>Outcome:</b> 
+            <b>Outcome:</b>
             terraform init: ${{ steps.terraform_init.outcome }}
             terraform plan: ${{ steps.terraform_plan.outcome }}
             terraform apply: ${{ steps.terraform_apply.outcome }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -87,6 +87,49 @@ jobs:
           rest_gateway_bot_name: "${{ secrets.REST_GATEWAY_BOT_NAME }}"
 
 
+      - name: Terraform show
+        id: terraform_show
+        shell: bash
+        working-directory: infra/terraform
+        continue-on-error: true
+        env:
+          TF_VAR_vultr_api_key: "${{ secrets.VULTR_API_KEY }}"
+          TF_VAR_github_runners_count: 1
+        run: >-
+          terraform show -json |
+          jq -r '.values.outputs."instance-details".value[][] | .name + "\n" + .ipv4 + "\n" + .ipv6 + "\n"' >
+          "outputs.json"
+          
+          cat <<EOF >> "${GITHUB_OUTPUT}"
+          instances<<EOF2
+          $( cat outputs.json  )
+          EOF2
+          EOF
+
+
+      - name: Send notification with terraform outputs
+        uses: rest-gateway/notification-action@1.0.9
+        if: always()
+        with:
+          message: |
+            <b>Workflow:</b> <code>${GITHUB_WORKFLOW}</code>
+            <b>Repository:</b> ${GITHUB_REPOSITORY} (${GITHUB_REF#refs/heads/})
+            <b>URL:</b> <code>https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}</code>
+
+            <b>Instances:</b>
+            ${{ steps.terraform_show.outputs.instances }}
+
+            <b>Outcome:</b> 
+            terraform init: ${{ steps.terraform_init.outcome }}
+            terraform plan: ${{ steps.terraform_plan.outcome }}
+            terraform apply: ${{ steps.terraform_apply.outcome }}
+
+          recipient: "${{ secrets.NOTIFICATIONS_DEFAULT_RECIPIENT }}"
+          rest_gateway_url: "${{ secrets.REST_GATEWAY_API_URL }}"
+          rest_gateway_token: "${{ secrets.REST_GATEWAY_TOKEN }}"
+          rest_gateway_bot_name: "${{ secrets.REST_GATEWAY_BOT_NAME }}"
+
+
       - name: Upload .version file to JFrog Artifactory (to keep the account alive)
         id: upload_to_artifactory
         shell: bash

--- a/.github/workflows/tear_down_runners.yml
+++ b/.github/workflows/tear_down_runners.yml
@@ -1,0 +1,199 @@
+---
+# yamllint disable rule:line-length
+# yamllint disable rule:truthy
+
+name: Tear down runners
+
+on: workflow_dispatch
+
+jobs:
+
+  notify_started:
+    name: Send notification on start
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Send notification on start
+        uses: rest-gateway/notification-action@1.0.9
+        with:
+          message: |
+            <b>Workflow:</b> <code>${GITHUB_WORKFLOW}</code>
+            <b>Repository:</b> ${GITHUB_REPOSITORY} (${GITHUB_REF#refs/heads/})
+            <b>URL:</b> <code>https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}</code>
+          recipient: "${{ secrets.NOTIFICATIONS_DEFAULT_RECIPIENT }}"
+          rest_gateway_url: "${{ secrets.REST_GATEWAY_API_URL }}"
+          rest_gateway_token: "${{ secrets.REST_GATEWAY_TOKEN }}"
+          rest_gateway_bot_name: "${{ secrets.REST_GATEWAY_BOT_NAME }}"
+
+
+  tear_down_runners:
+    name: Tear down GitHub runners
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Check out this repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.0.11
+
+
+      - name: Render SSH private key from a secret
+        id: ssh_private_key
+        shell: bash
+        working-directory: infra/terraform
+        run: >-
+          echo "${{ secrets.VULTR_RSA_PRIVATE_KEY }}" > ./id_rsa
+
+
+      - name: Terraform init
+        id: terraform_init
+        shell: bash
+        working-directory: infra/terraform
+        env:
+          TF_VAR_vultr_api_key: "${{ secrets.VULTR_API_KEY }}"
+          TF_VAR_github_runners_count: 0
+        run: >-
+          export TF_VAR_ansible_ghr_token=$( cat "${{ steps.get_ghr_token.outputs.token_filename }}" )
+
+          terraform init
+          -backend-config="endpoint=${{ secrets.S3_ENDPOINT }}"
+          -backend-config="access_key=${{ secrets.S3_ACCESS_KEY }}"
+          -backend-config="secret_key=${{ secrets.S3_SECRET_KEY }}"
+
+
+      - name: Terraform plan
+        id: terraform_plan
+        shell: bash
+        working-directory: infra/terraform
+        env:
+          TF_VAR_vultr_api_key: "${{ secrets.VULTR_API_KEY }}"
+          TF_VAR_github_runners_count: 0
+        run: >-
+          export TF_VAR_ansible_ghr_token=$( cat "${{ steps.get_ghr_token.outputs.token_filename }}" )
+
+          terraform plan
+
+
+      - name: Terraform apply
+        id: terraform_apply
+        shell: bash
+        working-directory: infra/terraform
+        env:
+          TF_VAR_vultr_api_key: "${{ secrets.VULTR_API_KEY }}"
+          TF_VAR_github_runners_count: 0
+        run: >-
+          export TF_VAR_ansible_ghr_token=$( cat "${{ steps.get_ghr_token.outputs.token_filename }}" )
+
+          terraform apply -auto-approve -no-color 2>&1 > terraform_apply.log
+
+
+      - name: Terraform show
+        id: terraform_show
+        shell: bash
+        working-directory: infra/terraform
+        continue-on-error: true
+        env:
+          TF_VAR_vultr_api_key: "${{ secrets.VULTR_API_KEY }}"
+          TF_VAR_github_runners_count: 0
+        run: |
+          terraform show -json
+
+
+      - name: Parse terraform show output
+        id: parse_terraform_show
+        shell: bash
+        working-directory: infra/terraform
+        continue-on-error: true
+        run: |
+          cat <<EOF > outputs.json
+          ${{ steps.terraform_show.outputs.stdout }}
+          EOF
+          
+          cat <<EOF >> "${GITHUB_OUTPUT}"
+          instances<<EOF2
+          $( cat outputs.json | jq -r '.values.outputs."instance-details".value[][] | .name + "\n" + .ipv4 + "\n" + .ipv6 + "\n"' )
+          EOF2
+          EOF
+
+
+      - name: Send notification with terraform outputs
+        uses: rest-gateway/notification-action@1.0.9
+        if: always()
+        with:
+          message: |
+            <b>Workflow:</b> <code>${GITHUB_WORKFLOW}</code>
+            <b>Repository:</b> ${GITHUB_REPOSITORY} (${GITHUB_REF#refs/heads/})
+            <b>URL:</b> <code>https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}</code>
+
+            <b>Instances:</b>
+            ${{ steps.parse_terraform_show.outputs.instances }}
+
+            <b>Outcome:</b> 
+            terraform init: ${{ steps.terraform_init.outcome }}
+            terraform plan: ${{ steps.terraform_plan.outcome }}
+            terraform apply: ${{ steps.terraform_apply.outcome }}
+
+          recipient: "${{ secrets.NOTIFICATIONS_DEFAULT_RECIPIENT }}"
+          rest_gateway_url: "${{ secrets.REST_GATEWAY_API_URL }}"
+          rest_gateway_token: "${{ secrets.REST_GATEWAY_TOKEN }}"
+          rest_gateway_bot_name: "${{ secrets.REST_GATEWAY_BOT_NAME }}"
+
+
+      - name: Upload terraform apply log
+        uses: actions/upload-artifact@v3.1.0
+        id: upload_terraform_apply_log
+        if: always()
+        with:
+          name: "terraform_apply.log"
+          path: "infra/terraform/terraform_apply.log"
+          if-no-files-found: error
+          retention-days: 90
+
+
+      - name: Upload terraform show result
+        uses: actions/upload-artifact@v3.1.0
+        id: upload_terraform_show_result
+        if: always()
+        with:
+          name: "outputs.json"
+          path: "infra/terraform/outputs.json"
+          if-no-files-found: error
+          retention-days: 90
+
+
+  after_build:
+    name: Send notification on finish
+    runs-on: ubuntu-latest
+
+    if: always()
+
+    needs:
+      - tear_down_runners
+
+    steps:
+
+      - name: Send notification on finish
+        uses: rest-gateway/notification-action@1.0.9
+        with:
+          message: |
+            <b>Workflow:</b>   ${GITHUB_WORKFLOW}
+            <b>Repository:</b> ${GITHUB_REPOSITORY}
+
+            <b>Tear down results:</b>
+            Status: ${{ needs.tear_down_runners.outputs.job_status }}
+
+          recipient: "${{ secrets.NOTIFICATIONS_DEFAULT_RECIPIENT }}"
+          rest_gateway_url: "${{ secrets.REST_GATEWAY_API_URL }}"
+          rest_gateway_token: "${{ secrets.REST_GATEWAY_TOKEN }}"
+          rest_gateway_bot_name: "${{ secrets.REST_GATEWAY_BOT_NAME }}"
+
+
+...

--- a/.github/workflows/tear_down_runners.yml
+++ b/.github/workflows/tear_down_runners.yml
@@ -116,7 +116,7 @@ jobs:
           cat <<EOF > outputs.json
           ${{ steps.terraform_show.outputs.stdout }}
           EOF
-          
+
           cat <<EOF >> "${GITHUB_OUTPUT}"
           instances<<EOF2
           $( cat outputs.json | jq -r '.values.outputs."instance-details".value[][] | .name + "\n" + .ipv4 + "\n" + .ipv6 + "\n"' )
@@ -136,7 +136,7 @@ jobs:
             <b>Instances:</b>
             ${{ steps.parse_terraform_show.outputs.instances }}
 
-            <b>Outcome:</b> 
+            <b>Outcome:</b>
             terraform init: ${{ steps.terraform_init.outcome }}
             terraform plan: ${{ steps.terraform_plan.outcome }}
             terraform apply: ${{ steps.terraform_apply.outcome }}


### PR DESCRIPTION
# Description

Nothing!


# Checklist

- [ ] Your code works
- [ ] The changes are cool
- [ ] The version is bumped
